### PR TITLE
Add cadquery2web

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you want to contribute, please read [this](CONTRIBUTING.md).
 * [cadquery-gui](https://github.com/jmwright/cadquery-gui) - A semi-maintained Electron-based CAD GUI built for CadQuery 1.x and 2.x.
 * [BlendQuery](https://github.com/uki-dev/blendquery) - CadQuery integration for Blender.
 * [Yet Another CAD Viewer](https://github.com/yeicor-3d/yet-another-cad-viewer) - A CAD viewer capable of displaying [OCP](https://github.com/CadQuery/OCP) models ([CadQuery](https://github.com/CadQuery/cadquery)/[Build123d](https://github.com/gumyr/build123d)/...) in a web browser.
+* [cadquery2web](https://github.com/30hours/cadquery2web) - A browser based CadQuery server.
 
 ## CLIs
 


### PR DESCRIPTION
Add cadquery2web (a web based tool to run CadQuery, preview and download STL files).

Can be hosted locally or the demo server can be used.